### PR TITLE
Improve the vsphere-iso boot_command

### DIFF
--- a/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
@@ -41,20 +41,15 @@
         },
         {
             "boot_command": [
-                " <wait>",
-                " <wait>",
-                " <wait>",
-                " <wait>",
-                " <wait>",
+                "<escOn><wait5><escOff><enter><wait>",
+                "<esc><wait5>",
+                "<enter><wait>",
+                "<f6><wait5>",
                 "<esc><wait>",
-                "<f6><wait>",
-                "<esc><wait>",
-                "<bs><bs><bs><bs><wait>",
-                " autoinstall<wait5>",
-                " ds=nocloud-net<wait5>",
-                ";s=http://<wait5>{{.HTTPIP}}<wait5>:{{.HTTPPort}}/<wait5>",
-                " ---<wait5>",
-                "<enter><wait5>"
+                "<bs><bs><bs><bs>",
+                "autoinstall ds=nocloud-net;s=http://<wait5>{{.HTTPIP}}<wait5>:{{.HTTPPort}}/<wait5>",
+                " ---",
+                "<enter>"
             ],
             "boot_wait": "5s",
             "cpus": "{{ user `cpus` }}",


### PR DESCRIPTION
In production vsphere hosts with highly variable loads it is difficult to accurately predict how long to wait before sending the boot_command.  By holding down "escape" at the beginning of the boot command you force the VM bios to show the "boot device" menu. From there you can more easily predict when to send the <esc> key that loads the ubuntu graphical boot menu and in-turn be able to predict what keys to press.